### PR TITLE
inject environment variables into the powershell process

### DIFF
--- a/src/main/java/com/stacktoheap/go/plugin/task/powershell/PowershellTaskExecutor.java
+++ b/src/main/java/com/stacktoheap/go/plugin/task/powershell/PowershellTaskExecutor.java
@@ -84,8 +84,12 @@ public class PowershellTaskExecutor implements TaskExecutor {
         AddPowershellArguments(taskConfig, command);
         AddScript(taskConfig, command);
 
+		Map<String, String> environmentVariables = taskContext.environment().asMap();
+		
         ProcessBuilder processBuilder = new ProcessBuilder(command);
-
+		if (environmentVariables != null && !environmentVariables.isEmpty()) {
+            processBuilder.environment().putAll(environmentVariables);
+        }
         processBuilder.directory(new File(taskContext.workingDir()));
         return processBuilder;
     }


### PR DESCRIPTION
retrieve the environment variable set in Go via TaskContext and inject
them into the powershell process that is created via ProcessBuilder
